### PR TITLE
Add optional user session LWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ For efficient searches, attributes can be defined as **indexed attributes** by p
 All write-queries are done conditionally via Cassandra Lightweight Transactions. Therefore we store a version column in each of the tables. To be able to use this to get notified if a conflicting change occured after data was read, the entityVersion is exposed via a **readonly attribute readonly.entityVersion**.
 In order to pass a version in update operations, one can use the corresponding attribute **internal.entityVersion**.
 
+Lightweight transactions for user sessions are disabled by default and can be enabled by setting the environment variable `KC_COMMUNITY_DATASTORE_CASSANDRA_USER_SESSION_LWT_ENABLED=true` (or system property `kc.community.datastore.cassandra.userSession.lwt.enabled=true`).
+
 ### Uniqueness across username and password
 
 This extension supports additional checks to prevent setting username to a value that is already as email of another user and setting email to a value used as username.

--- a/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/CassandraFeatures.java
+++ b/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/CassandraFeatures.java
@@ -1,0 +1,17 @@
+package de.arbeitsagentur.opdt.keycloak.cassandra;
+
+public class CassandraFeatures {
+    private static final String ENV_USER_SESSION_LWT = "KC_COMMUNITY_DATASTORE_CASSANDRA_USER_SESSION_LWT_ENABLED";
+    private static final String PROP_USER_SESSION_LWT = "kc.community.datastore.cassandra.userSession.lwt.enabled";
+
+    private static final boolean userSessionLwtEnabled;
+
+    static {
+        userSessionLwtEnabled = Boolean.parseBoolean(System.getenv(ENV_USER_SESSION_LWT))
+                || Boolean.parseBoolean(System.getProperty(PROP_USER_SESSION_LWT));
+    }
+
+    public static boolean isUserSessionLwtEnabled() {
+        return userSessionLwtEnabled;
+    }
+}

--- a/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/userSession/persistence/UserSessionDao.java
+++ b/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/userSession/persistence/UserSessionDao.java
@@ -17,19 +17,27 @@ package de.arbeitsagentur.opdt.keycloak.cassandra.userSession.persistence;
 
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.mapper.annotations.*;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import de.arbeitsagentur.opdt.keycloak.cassandra.BaseDao;
+import de.arbeitsagentur.opdt.keycloak.cassandra.transaction.TransactionalDao;
 import de.arbeitsagentur.opdt.keycloak.cassandra.userSession.persistence.entities.AttributeToUserSessionMapping;
 import de.arbeitsagentur.opdt.keycloak.cassandra.userSession.persistence.entities.UserSession;
 import de.arbeitsagentur.opdt.keycloak.cassandra.userSession.persistence.entities.UserSessionToAttributeMapping;
 import java.util.List;
 
 @Dao
-public interface UserSessionDao extends BaseDao {
-    @Update
-    void insertOrUpdate(UserSession session);
+public interface UserSessionDao extends TransactionalDao<UserSession> {
+    @Insert(ifNotExists = true)
+    void insert(UserSession session);
 
-    @Update(ttl = ":ttl")
-    void insertOrUpdate(UserSession session, int ttl);
+    @Insert(ifNotExists = true, ttl = ":ttl")
+    void insert(UserSession session, int ttl);
+
+    @Update(customIfClause = "version = :expectedVersion")
+    ResultSet update(UserSession session, long expectedVersion);
+
+    @Update(customIfClause = "version = :expectedVersion", ttl = ":ttl")
+    ResultSet update(UserSession session, long expectedVersion, int ttl);
 
     @Select(customWhereClause = "id = :id")
     UserSession findById(String id);

--- a/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/userSession/persistence/entities/UserSession.java
+++ b/core/src/main/java/de/arbeitsagentur/opdt/keycloak/cassandra/userSession/persistence/entities/UserSession.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import de.arbeitsagentur.opdt.keycloak.common.ExpirableEntity;
+import de.arbeitsagentur.opdt.keycloak.cassandra.transaction.TransactionalEntity;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.*;
@@ -33,9 +34,11 @@ import org.keycloak.models.UserSessionModel;
 @AllArgsConstructor
 @Entity
 @CqlName("user_sessions")
-public class UserSession implements ExpirableEntity {
+public class UserSession implements ExpirableEntity, TransactionalEntity {
     @PartitionKey
     private String id;
+
+    private Long version;
 
     private String realmId;
     private String userId;

--- a/core/src/main/resources/cassandra/migration/0006_user_sessions_version.cql
+++ b/core/src/main/resources/cassandra/migration/0006_user_sessions_version.cql
@@ -1,0 +1,1 @@
+ALTER TABLE user_sessions ADD version bigint;


### PR DESCRIPTION
## Summary
- add feature toggle `CassandraFeatures` to control user session lightweight transactions
- extend `UserSession` entity with version and transactional support
- extend `UserSessionDao` for conditional updates
- implement optional LWT logic in `CassandraUserSessionRepository`
- document new environment property
- add migration for user session version column

## Testing
- `mvn -q -DskipTests install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683d698837a083218a7588f84940a6ff